### PR TITLE
Add smartctl NETAPP Vendor SAS disk support

### DIFF
--- a/TA-SH_files_for_freenas/cpu_uptime_version_drives.sh
+++ b/TA-SH_files_for_freenas/cpu_uptime_version_drives.sh
@@ -39,21 +39,42 @@ uptime | awk '{ print "SystemLoad1min="$10"\n""SystemLoad5min="$11"\n""SystemLoa
 for i in $(sysctl -n kern.disks)
 do
 
-        DevModelFamily=`smartctl -a /dev/$i | awk '/Model Family:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
-        DevName=`smartctl -a /dev/$i | awk '/Device Model:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
-        DevSerNum=`smartctl -a /dev/$i | awk '/Serial Number:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
-        DevLU_WWN_Device_Id=`smartctl -a /dev/$i | awk '/LU WWN Device Id:/{print $0}' | awk '{ print substr($0, index($0,$5)) }'`
-        DevFirmware_Version=`smartctl -a /dev/$i | awk '/Firmware Version:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
-        DevUser_Capacity=`smartctl -a /dev/$i | awk '/User Capacity:/{print $0}' | awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g'`
-        DevSector_Size=`smartctl -a /dev/$i | awk '/Sector Size:/{print $0}' | awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
-        Dev_is=`smartctl -a /dev/$i | awk '/Device is:/{print $0}' | awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
-        DevSATA_Version=`smartctl -a /dev/$i | awk '/SATA Version is:/{print $0}' | awk '{ print substr($0, index($0,$5)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
-        DevATA_Version=`smartctl -a /dev/$i | awk '/^ATA Version is:/{print $0}' | awk '{ print substr($0, index($0,$4)) }'| sed 's/\,//g' | sed 's/\ /_/g'`
-        DevLocal_Time=`smartctl -a /dev/$i | awk '/Local Time is:/{print $0}' | awk '{ print substr($0, index($0,$4)) }'`
-        DevSMART_support=`smartctl -a /dev/$i | awk '/SMART support is:/{print $0}' | awk '{ print substr($0, index($0,$4)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
-        DevATA_Version=`smartctl -a /dev/$i | awk '/ATA Version is:/{print $0}' | awk '{ print substr($0, index($0,$4)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
+	CurrentDevSMART=`smartctl -a /dev/$i`
+	Vendor="$(echo "$CurrentDevSMART" | awk '/Vendor:/{print $2}')"
+	
+	if [ ! -z $Vendor ]
+	then
+		DevModelFamily=`echo "$CurrentDevSMART" | awk '/Product:/{print $0}' | awk '{ print substr($0, index($0,$2)) }'`
+		DevName=`echo "$CurrentDevSMART" | awk '/Vendor:/{print $0}' | awk '{ print substr($0, index($0,$2)) }'`
+		DevSerNum=`echo "$CurrentDevSMART" | awk '/Serial number:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
+		DevLU_WWN_Device_Id=`echo "$CurrentDevSMART" | awk '/Logical Unit id:/{print $0}' | awk '{ print substr($0, index($0,$4)) }'`
+		DevFirmware_Version=`echo "$CurrentDevSMART" | awk '/Revision:/{print $0}' | awk '{ print substr($0, index($0,$2)) }'`
+		DevUser_Capacity=`echo "$CurrentDevSMART" | awk '/User Capacity:/{print $0}' | awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g'`
+		DevSector_Size=`echo "$CurrentDevSMART" | awk '/Logical block size:/{print $0}' | awk '{ print substr($0, index($0,$4)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
+		DevRotation_Rate=`echo "$CurrentDevSMART" | awk '/Rotation Rate:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
+		Dev_is=""
+		DevSATA_Version=`echo "$CurrentDevSMART" | awk '/Transport protocol:/{print $0}' | awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
+		DevATA_Version=""
+		DevLocal_Time=`echo "$CurrentDevSMART" | awk '/Local Time is:/{print $0}' | awk '{ print substr($0, index($0,$4)) }'`
+		DevSMART_support=`echo "$CurrentDevSMART" | awk '/SMART support is:/{print $0}' | awk '{ print substr($0, index($0,$4)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
+		DevTemp=`echo "$CurrentDevSMART" | awk '/Temperature_Celsius/ || /Current Drive Temperature:/{print $0}' | awk '$10>1 {print $10;next};{print $4}'`
+	else
+		DevModelFamily=`echo "$CurrentDevSMART" | awk '/Model Family:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
+		DevName=`echo "$CurrentDevSMART" | awk '/Device Model:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
+		DevSerNum=`echo "$CurrentDevSMART" | awk '/Serial Number:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
+		DevLU_WWN_Device_Id=`echo "$CurrentDevSMART" | awk '/LU WWN Device Id:/{print $0}' | awk '{ print substr($0, index($0,$5)) }'`
+		DevFirmware_Version=`echo "$CurrentDevSMART" | awk '/Firmware Version:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
+		DevUser_Capacity=`echo "$CurrentDevSMART" | awk '/User Capacity:/{print $0}' | awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g'`
+		DevSector_Size=`echo "$CurrentDevSMART" | awk '/Sector Size:/{print $0}' | awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
+		DevRotation_Rate=""
+		Dev_is=`echo "$CurrentDevSMART" | awk '/Device is:/{print $0}' | awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
+		DevSATA_Version=`echo "$CurrentDevSMART" | awk '/SATA Version is:/{print $0}' | awk '{ print substr($0, index($0,$5)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
+		DevATA_Version=`echo "$CurrentDevSMART" | awk '/^ATA Version is:/{print $0}' | awk '{ print substr($0, index($0,$4)) }'| sed 's/\,//g' | sed 's/\ /_/g'`
+		DevLocal_Time=`echo "$CurrentDevSMART" | awk '/Local Time is:/{print $0}' | awk '{ print substr($0, index($0,$4)) }'`
+		DevSMART_support=`echo "$CurrentDevSMART" | awk '/SMART support is:/{print $0}' | awk '{ print substr($0, index($0,$4)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
+		DevTemp=`echo "$CurrentDevSMART" | awk '/Temperature_Celsius/{print $0}' | awk '{print $10}'`
+	fi
 
-
-        DevTemp=`smartctl -a /dev/$i | awk '/Temperature_Celsius/{print $0}' | awk '{print $10}'`
-        echo dev=$i, temperature=$DevTemp, DriveSerialNumber=$DevSerNum, DriveBrand=$DevName, DriveModel=$DevModelFamily, DevLU_WWN_Device_Id=$DevLU_WWN_Device_Id, DevFirmware_Version=$DevFirmware_Version, DevUser_Capacity=$DevUser_Capacity, DevSector_Size="$DevSector_Size", DevRotation_Rate="$DevRotation_Rate", Dev_is="$Dev_is", DevATA_Version=$DevATA_Version, DevSATA_Version="$DevSATA_Version", DevLocal_Time="$DevLocal_Time", DevSMART_support="$DevSMART_support"| logger
+    echo dev=$i, temperature=$DevTemp, DriveSerialNumber=$DevSerNum, DriveBrand=$DevName, DriveModel=$DevModelFamily, DevLU_WWN_Device_Id=$DevLU_WWN_Device_Id, DevFirmware_Version=$DevFirmware_Version, DevUser_Capacity=$DevUser_Capacity, DevSector_Size="$DevSector_Size", DevRotation_Rate="$DevRotation_Rate", Dev_is="$Dev_is", DevATA_Version=$DevATA_Version, DevSATA_Version="$DevSATA_Version", DevLocal_Time="$DevLocal_Time", DevSMART_support="$DevSMART_support" | logger
 done
+


### PR DESCRIPTION
- modified cpu_uptime_version_drives script for more efficient use of smartctl
- added support for Vendor (NETAPP style SAS drives) which previously provided no data