### PR TITLE
cron script updates

### DIFF
--- a/TA-SH_files_for_freenas/cpu_uptime_version_drives.sh
+++ b/TA-SH_files_for_freenas/cpu_uptime_version_drives.sh
@@ -7,12 +7,15 @@
 sysctl -a | egrep -E 'cpu\.[0-9]+\.temp' | cut -d'.' -f2 -f3 -f4 | tr -d ' ' | sed 's/\:/\=/g' | sed 's/cpu./cpuid\=/g' | sed 's/\./\,/g' | logger
 
 
-#Get Freenas Version
+#Get Free(nas|BSD) Version
 
-FreenasVersion=$(cat /etc/version)
-
+if [ -f /etc/version ];
+        then
+                FreenasVersion=$(cat /etc/version)
+        else
+                FreenasVersion=$(uname -srm)
+fi
 echo FreenasVersion=$FreenasVersion | logger
-
 
 #Get systemload
 
@@ -65,5 +68,4 @@ do
 
     echo dev=$i, Dev_Current_Pending_Sector=$Dev_Current_Pending_Sector, Dev_Offline_Uncorrectable=$Dev_Offline_Uncorrectable, temperature=$DevTemp, DriveSerialNumber=$DevSerNum, DriveBrand=$DevName, DriveModel=$DevModelFamily, DevLU_WWN_Device_Id=$DevLU_WWN_Device_Id, DevFirmware_Version=$DevFirmware_Version, DevUser_Capacity=$DevUser_Capacity, DevSector_Size="$DevSector_Size", DevRotation_Rate="$DevRotation_Rate", Dev_is="$Dev_is", DevATA_Version=$DevATA_Version, DevSATA_Version="$DevSATA_Version", DevLocal_Time="$DevLocal_Time", DevSMART_support="$DevSMART_support" | logger
 done
-
 

--- a/TA-SH_files_for_freenas/cpu_uptime_version_drives.sh
+++ b/TA-SH_files_for_freenas/cpu_uptime_version_drives.sh
@@ -3,8 +3,9 @@
 #credits
 # https://gist.github.com/i3luefire/242844141fde57d5cafd
 # https://forums.freenas.org/index.php?threads/how-to-monitor-system-cpu-hdd-mobo-gpu-temperatures-on-freenas-8.2994/page-3
+# Need full path (if not /bin /usr/bin) for FreeBSD 10.x
 
-sysctl -a | egrep -E 'cpu\.[0-9]+\.temp' | cut -d'.' -f2 -f3 -f4 | tr -d ' ' | sed 's/\:/\=/g' | sed 's/cpu./cpuid\=/g' | sed 's/\./\,/g' | logger
+/sbin/sysctl -a | egrep -E 'cpu\.[0-9]+\.temp' | cut -d'.' -f2 -f3 -f4 | tr -d ' ' | sed 's/\:/\=/g' | sed 's/cpu./cpuid\=/g' | sed 's/\./\,/g' | /usr/bin/logger -p local0.debug
 
 
 #Get Free(nas|BSD) Version
@@ -13,59 +14,59 @@ if [ -f /etc/version ];
         then
                 FreenasVersion=$(cat /etc/version)
         else
-                FreenasVersion=$(uname -srm)
+                FreenasVersion=$(uname -srm | sed s/\ /-/g)
 fi
-echo FreenasVersion=$FreenasVersion | logger
+echo FreenasVersion=$FreenasVersion | /usr/bin/logger -p local0.debug
 
 #Get systemload
 
-uptime | awk '{ print "SystemLoad1min="$10"\n""SystemLoad5min="$11"\n""SystemLoad10min="$12}"\n"' | logger
+/usr/bin/uptime | /usr/bin/awk '{ print "SystemLoad1min="$10"\n""SystemLoad5min="$11"\n""SystemLoad10min="$12}"\n"' | /usr/bin/logger -p local0.debug
 
 #Get Drive info
 
-for i in $(sysctl -n kern.disks)
+for i in $(/sbin/sysctl -n kern.disks)
 do
 
-        CurrentDevSMART=`smartctl -a /dev/$i`
-        Vendor="$(echo "$CurrentDevSMART" | awk '/Vendor:/{print $2}')"
+        CurrentDevSMART=`/usr/local/sbin/smartctl -a /dev/$i`
+        Vendor="$(echo "$CurrentDevSMART" | /usr/bin/awk '/Vendor:/{print $2}')"
         
         if [ ! -z $Vendor ]
         then
-                DevModelFamily=`echo "$CurrentDevSMART" | awk '/Product:/{print $0}' | awk '{ print substr($0, index($0,$2)) }'`
-                Dev_Current_Pending_Sector=`echo "$CurrentDevSMART" | awk '/Current_Pending_Sector/{print $0}' | awk -F " " '{print $NF}'`
-                Dev_Offline_Uncorrectable=`echo "$CurrentDevSMART"  | awk '/Offline_Uncorrectable/{print $0}' | awk -F " " '{print $NF}'`
-                DevName=`echo "$CurrentDevSMART" | awk '/Vendor:/{print $0}' | awk '{ print substr($0, index($0,$2)) }'`
-                DevSerNum=`echo "$CurrentDevSMART" | awk '/Serial number:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
-                DevLU_WWN_Device_Id=`echo "$CurrentDevSMART" | awk '/Logical Unit id:/{print $0}' | awk '{ print substr($0, index($0,$4)) }'`
-                DevFirmware_Version=`echo "$CurrentDevSMART" | awk '/Revision:/{print $0}' | awk '{ print substr($0, index($0,$2)) }'`
-                DevUser_Capacity=`echo "$CurrentDevSMART" | awk '/User Capacity:/{print $0}' | awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g'`
-                DevSector_Size=`echo "$CurrentDevSMART" | awk '/Logical block size:/{print $0}' | awk '{ print substr($0, index($0,$4)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
-                DevRotation_Rate=`echo "$CurrentDevSMART" | awk '/Rotation Rate:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
+                DevModelFamily=`echo "$CurrentDevSMART" | /usr/bin/awk '/Product:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$2)) }'`
+                Dev_Current_Pending_Sector=`echo "$CurrentDevSMART" | /usr/bin/awk '/Current_Pending_Sector/{print $0}' | /usr/bin/awk -F " " '{print $NF}'`
+                Dev_Offline_Uncorrectable=`echo "$CurrentDevSMART"  | /usr/bin/awk '/Offline_Uncorrectable/{print $0}' | /usr/bin/awk -F " " '{print $NF}'`
+                DevName=`echo "$CurrentDevSMART" | /usr/bin/awk '/Vendor:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$2)) }'`
+                DevSerNum=`echo "$CurrentDevSMART" | /usr/bin/awk '/Serial number:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$3)) }'`
+                DevLU_WWN_Device_Id=`echo "$CurrentDevSMART" | /usr/bin/awk '/Logical Unit id:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$4)) }'`
+                DevFirmware_Version=`echo "$CurrentDevSMART" | /usr/bin/awk '/Revision:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$2)) }'`
+                DevUser_Capacity=`echo "$CurrentDevSMART" | /usr/bin/awk '/User Capacity:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g'`
+                DevSector_Size=`echo "$CurrentDevSMART" | /usr/bin/awk '/Logical block size:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$4)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
+                DevRotation_Rate=`echo "$CurrentDevSMART" | /usr/bin/awk '/Rotation Rate:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$3)) }'`
                 Dev_is=""
-                DevSATA_Version=`echo "$CurrentDevSMART" | awk '/Transport protocol:/{print $0}' | awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
+                DevSATA_Version=`echo "$CurrentDevSMART" | /usr/bin/awk '/Transport protocol:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
                 DevATA_Version=""
-                DevLocal_Time=`echo "$CurrentDevSMART" | awk '/Local Time is:/{print $0}' | awk '{ print substr($0, index($0,$4)) }'`
-                DevSMART_support=`echo "$CurrentDevSMART" | awk '/SMART support is:/{print $0}' | awk '{ print substr($0, index($0,$4)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
-                DevTemp=`echo "$CurrentDevSMART" | awk '/Temperature_Celsius/ || /Current Drive Temperature:/{print $0}' | awk '$10>1 {print $10;next};{print $4}'`
+                DevLocal_Time=`echo "$CurrentDevSMART" | /usr/bin/awk '/Local Time is:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$4)) }'`
+                DevSMART_support=`echo "$CurrentDevSMART" | /usr/bin/awk '/SMART support is:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$4)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
+                DevTemp=`echo "$CurrentDevSMART" | /usr/bin/awk '/Temperature_Celsius/ || /Current Drive Temperature:/{print $0}' | /usr/bin/awk '$10>1 {print $10;next};{print $4}'`
         else
-                DevModelFamily=`echo "$CurrentDevSMART" | awk '/Model Family:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
-                Dev_Current_Pending_Sector=`echo "$CurrentDevSMART"  | awk '/Current_Pending_Sector/{print $0}' | awk -F " " '{print $NF}'`
-                Dev_Offline_Uncorrectable=`echo "$CurrentDevSMART"  | awk '/Offline_Uncorrectable/{print $0}' | awk -F " " '{print $NF}'`
-                DevName=`echo "$CurrentDevSMART" | awk '/Device Model:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
-                DevSerNum=`echo "$CurrentDevSMART" | awk '/Serial Number:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
-                DevLU_WWN_Device_Id=`echo "$CurrentDevSMART" | awk '/LU WWN Device Id:/{print $0}' | awk '{ print substr($0, index($0,$5)) }'`
-                DevFirmware_Version=`echo "$CurrentDevSMART" | awk '/Firmware Version:/{print $0}' | awk '{ print substr($0, index($0,$3)) }'`
-                DevUser_Capacity=`echo "$CurrentDevSMART" | awk '/User Capacity:/{print $0}' | awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g'`
-                DevSector_Size=`echo "$CurrentDevSMART" | awk '/Sector Size:/{print $0}' | awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
+                DevModelFamily=`echo "$CurrentDevSMART" | /usr/bin/awk '/Model Family:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$3)) }'`
+                Dev_Current_Pending_Sector=`echo "$CurrentDevSMART"  | /usr/bin/awk '/Current_Pending_Sector/{print $0}' | /usr/bin/awk -F " " '{print $NF}'`
+                Dev_Offline_Uncorrectable=`echo "$CurrentDevSMART"  | /usr/bin/awk '/Offline_Uncorrectable/{print $0}' | /usr/bin/awk -F " " '{print $NF}'`
+                DevName=`echo "$CurrentDevSMART" | /usr/bin/awk '/Device Model:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$3)) }'`
+                DevSerNum=`echo "$CurrentDevSMART" | /usr/bin/awk '/Serial Number:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$3)) }'`
+                DevLU_WWN_Device_Id=`echo "$CurrentDevSMART" | /usr/bin/awk '/LU WWN Device Id:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$5)) }'`
+                DevFirmware_Version=`echo "$CurrentDevSMART" | /usr/bin/awk '/Firmware Version:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$3)) }'`
+                DevUser_Capacity=`echo "$CurrentDevSMART" | /usr/bin/awk '/User Capacity:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g'`
+                DevSector_Size=`echo "$CurrentDevSMART" | /usr/bin/awk '/Sector Size:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
                 DevRotation_Rate=""
-                Dev_is=`echo "$CurrentDevSMART" | awk '/Device is:/{print $0}' | awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
-                DevSATA_Version=`echo "$CurrentDevSMART" | awk '/SATA Version is:/{print $0}' | awk '{ print substr($0, index($0,$5)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
-                DevATA_Version=`echo "$CurrentDevSMART" | awk '/^ATA Version is:/{print $0}' | awk '{ print substr($0, index($0,$4)) }'| sed 's/\,//g' | sed 's/\ /_/g'`
-                DevLocal_Time=`echo "$CurrentDevSMART" | awk '/Local Time is:/{print $0}' | awk '{ print substr($0, index($0,$4)) }'`
-                DevSMART_support=`echo "$CurrentDevSMART" | awk '/SMART support is:/{print $0}' | awk '{ print substr($0, index($0,$4)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
-                DevTemp=`echo "$CurrentDevSMART" | awk '/Temperature_Celsius/{print $0}' | awk '{print $10}'`
+                Dev_is=`echo "$CurrentDevSMART" | /usr/bin/awk '/Device is:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$3)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
+                DevSATA_Version=`echo "$CurrentDevSMART" | /usr/bin/awk '/SATA Version is:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$5)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
+                DevATA_Version=`echo "$CurrentDevSMART" | /usr/bin/awk '/^ATA Version is:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$4)) }'| sed 's/\,//g' | sed 's/\ /_/g'`
+                DevLocal_Time=`echo "$CurrentDevSMART" | /usr/bin/awk '/Local Time is:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$4)) }'`
+                DevSMART_support=`echo "$CurrentDevSMART" | /usr/bin/awk '/SMART support is:/{print $0}' | /usr/bin/awk '{ print substr($0, index($0,$4)) }' | sed 's/\,//g' | sed 's/\ /_/g'`
+                DevTemp=`echo "$CurrentDevSMART" | /usr/bin/awk '/Temperature_Celsius/{print $0}' | /usr/bin/awk '{print $10}'`
         fi
 
-    echo dev=$i, Dev_Current_Pending_Sector=$Dev_Current_Pending_Sector, Dev_Offline_Uncorrectable=$Dev_Offline_Uncorrectable, temperature=$DevTemp, DriveSerialNumber=$DevSerNum, DriveBrand=$DevName, DriveModel=$DevModelFamily, DevLU_WWN_Device_Id=$DevLU_WWN_Device_Id, DevFirmware_Version=$DevFirmware_Version, DevUser_Capacity=$DevUser_Capacity, DevSector_Size="$DevSector_Size", DevRotation_Rate="$DevRotation_Rate", Dev_is="$Dev_is", DevATA_Version=$DevATA_Version, DevSATA_Version="$DevSATA_Version", DevLocal_Time="$DevLocal_Time", DevSMART_support="$DevSMART_support" | logger
+    echo dev=$i, Dev_Current_Pending_Sector=$Dev_Current_Pending_Sector, Dev_Offline_Uncorrectable=$Dev_Offline_Uncorrectable, temperature=$DevTemp, DriveSerialNumber=$DevSerNum, DriveBrand=$DevName, DriveModel=$DevModelFamily, DevLU_WWN_Device_Id=$DevLU_WWN_Device_Id, DevFirmware_Version=$DevFirmware_Version, DevUser_Capacity=$DevUser_Capacity, DevSector_Size="$DevSector_Size", DevRotation_Rate="$DevRotation_Rate", Dev_is="$Dev_is", DevATA_Version=$DevATA_Version, DevSATA_Version="$DevSATA_Version", DevLocal_Time="$DevLocal_Time", DevSMART_support="$DevSMART_support" | /usr/bin/logger -p local0.debug
 done
 

--- a/TA-SH_files_for_freenas/nics.sh
+++ b/TA-SH_files_for_freenas/nics.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 #Get nic info
-for i in `ifconfig -ul`; do
+for i in `/sbin/ifconfig -ul`; do
         if [ "$i" != "lo0" ]; then
-                h=`echo \$i | sed 's/[0-9]\{0,10\}\$//g'`
-                j=`echo \$i | awk -F'[^0-9]*' '{print $2}'`
-                sysctl -a | grep dev.$h.$j | sed 's/\:/\ \=/g' | logger
+                h=`echo \$i | /usr/bin/sed 's/[0-9]\{0,10\}\$//g'`
+                j=`echo \$i | /usr/bin/awk -F'[^0-9]*' '{print $2}'`
+                /sbin/sysctl -a | grep dev.$h.$j | sed 's/\:/\ \=/g' | /usr/bin/logger -p local0.debug
         fi
 done

--- a/TA-SH_files_for_freenas/nics.sh
+++ b/TA-SH_files_for_freenas/nics.sh
@@ -1,3 +1,9 @@
+#!/bin/sh
 #Get nic info
-
-sysctl -a | grep dev.em. | sed 's/\:/\ \=/g' | logger
+for i in `ifconfig -ul`; do
+        if [ "$i" != "lo0" ]; then
+                h=`echo \$i | sed 's/[0-9]\{0,10\}\$//g'`
+                j=`echo \$i | awk -F'[^0-9]*' '{print $2}'`
+                sysctl -a | grep dev.$h.$j | sed 's/\:/\ \=/g' | logger
+        fi
+done

--- a/TA-SH_files_for_freenas/nics.sh
+++ b/TA-SH_files_for_freenas/nics.sh
@@ -4,6 +4,6 @@ for i in `/sbin/ifconfig -ul`; do
         if [ "$i" != "lo0" ]; then
                 h=`echo \$i | /usr/bin/sed 's/[0-9]\{0,10\}\$//g'`
                 j=`echo \$i | /usr/bin/awk -F'[^0-9]*' '{print $2}'`
-                /sbin/sysctl -a | grep dev.$h.$j | sed 's/\:/\ \=/g' | /usr/bin/logger -p local0.debug
+                /sbin/sysctl -a dev.$h.$j | sed 's/\:/\ \=/g' | /usr/bin/logger -p local0.debug
         fi
 done

--- a/TA-SH_files_for_freenas/user_group_space.sh
+++ b/TA-SH_files_for_freenas/user_group_space.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+ 
+declare -A GroupSpace
+while read key value; do ((GroupSpace[$key] += value)); done < <(while read line; do /sbin/zfs groupspace -Hp -o name,used $line; done < <(/sbin/zfs list -H | awk '{print $1}'))
+for key in "${!GroupSpace[@]}"; do echo "GroupName $key" ${GroupSpace[$key]}; done | logger -p local0.debug
+
+declare -A UserSpace
+while read key value; do ((UserSpace[$key] += value)); done < <(while read line; do /sbin/zfs userspace -Hp -o name,used $line; done < <(/sbin/zfs list -H | awk '{print $1}'))
+for key in "${!UserSpace[@]}"; do echo "UserName $key" ${UserSpace[$key]}; done | logger -p local0.debug
+

--- a/TA-SH_files_for_freenas/zpoolinfo.sh
+++ b/TA-SH_files_for_freenas/zpoolinfo.sh
@@ -1,22 +1,13 @@
 #! /bin/sh
 
 #NAME      SIZE  ALLOC   FREE  EXPANDSZ   FRAG    CAP  DEDUP  HEALTH  ALTROOT
-
-#zpool list SSD64gb | awk '{ print "PoolName="$1", ""Size="$2", ""Allocated="$3}", ""PoolName="$1", ""Size="$2", ""Allocated="$3}", "'
-
-
+#11.2 adds field CKPOINT
 
 for i in $(zpool list | awk 'NR>1' | awk '{print $1}')
 do
-        PoolName=`zpool list $i | awk 'NR>1' | awk '{print $1}'`
-        Size=`zpool list $i  | awk 'NR>1' | awk '{print $2}'`
-        Allocated=`zpool list $i  | awk 'NR>1' | awk '{print $3}'`
-        Free=`zpool list $i  | awk 'NR>1' | awk '{print $4}'`
-        EXPANDSZ=`zpool list $i  | awk 'NR>1' | awk '{print $5}'`
-        FRAG=`zpool list $i | awk 'NR>1' | awk '{print $6}'`
-        CAP=`zpool list $i  | awk 'NR>1' | awk '{print $7}'`
-        DEDUP=`zpool list $i  | awk 'NR>1' | awk '{print $8}'`
-        HEALTH=`zpool list $i  | awk 'NR>1' | awk '{print $9}'`
-        ALTROOT=`zpool list $i  | awk 'NR>1' | awk '{print $10}'`
-        echo PoolName=$PoolName, Size=$Size, Allocated=$Allocated, Free=$Free, EXPANDSZ=$EXPANDSZ, FRAG=$FRAG, CAP=$CAP, DEDUP=$DEDUP, HEALTH=$HEALTH, ALTROOT=$ALTROUT  | logger
+        USED=$(zfs get used $i | grep used | awk '{print$3}'| sed s/T//g)
+        FREE=$(zfs get available $i | grep available | awk '{print$3}'| sed s/T//g)
+        SIZE=$(echo "$USED + $FREE" | bc)
+        COMP=$(zfs get compressratio $i | grep comp | awk '{print$3}')
+        echo PoolName=$i, Size=$SIZE\T, Allocated=$USED\T, Free=$FREE\T, EXPANDSZ=$(zpool get -H expandsize $i | awk '{print$3}'), FRAG=$(zpool get -H fragmentation $i | awk '{print$3}'), CAP=$(zpool get -H capacity $i | awk '{print$3}'), DEDUP=$(zpool get -H dedupratio $i | awk '{print$3}'), HEALTH=$(zpool get -H health $i | awk '{print$3}'), ALTROOT=$(zpool get -H altroot $i | awk '{print$3}'), Compression:$COMP | logger
 done

--- a/TA-SH_files_for_freenas/zpoolinfo.sh
+++ b/TA-SH_files_for_freenas/zpoolinfo.sh
@@ -1,13 +1,10 @@
-#! /bin/sh
+#!/bin/sh
 
-#NAME      SIZE  ALLOC   FREE  EXPANDSZ   FRAG    CAP  DEDUP  HEALTH  ALTROOT
-#11.2 adds field CKPOINT
-
-for i in $(zpool list | awk 'NR>1' | awk '{print $1}')
+for i in $(/sbin/zpool list -H | awk '{print $1}')
 do
-        USED=$(zfs get used $i | grep used | awk '{print$3}'| sed s/T//g)
-        FREE=$(zfs get available $i | grep available | awk '{print$3}'| sed s/T//g)
+        USED=$(/sbin/zfs get -Hp used $i | awk 'BEGIN{print "scale=1"}{print $3" / 1024 / 1024 / 1024 / 1024"}' | bc)
+        FREE=$(/sbin/zfs get -Hp available $i | awk 'BEGIN{print "scale=1"}{print $3" / 1024 / 1024 / 1024 / 1024"}' | bc)
         SIZE=$(echo "$USED + $FREE" | bc)
-        COMP=$(zfs get compressratio $i | grep comp | awk '{print$3}')
-        echo PoolName=$i, Size=$SIZE\T, Allocated=$USED\T, Free=$FREE\T, EXPANDSZ=$(zpool get -H expandsize $i | awk '{print$3}'), FRAG=$(zpool get -H fragmentation $i | awk '{print$3}'), CAP=$(zpool get -H capacity $i | awk '{print$3}'), DEDUP=$(zpool get -H dedupratio $i | awk '{print$3}'), HEALTH=$(zpool get -H health $i | awk '{print$3}'), ALTROOT=$(zpool get -H altroot $i | awk '{print$3}'), Compression:$COMP | logger
+        echo PoolName=$i, Size=$SIZE\T, Allocated=$USED\T, Free=$FREE\T, EXPANDSZ=$(/sbin/zpool get -H expandsize $i | awk '{print$3}'), FRAG=$(/sbin/zpool get -H fragmentation $i | awk '{print$3}'), CAP=$(/sbin/zpool get -H capacity $i | awk '{print$3}'), DEDUP=$(/sbin/zpool get -H dedupratio $i | awk '{print$3}'), HEALTH=$(/sbin/zpool get -H health $i | awk '{print$3}'), ALTROOT=$(/sbin/zpool get -H altroot $i | awk '{print$3}'), Compression=$(/sbin/zfs get -H compressratio $i | awk '{print$3}') | /usr/bin/logger -p local0.debug
+
 done

--- a/default/inputs.conf
+++ b/default/inputs.conf
@@ -1,21 +1,8 @@
 [udp://1514]
-connection_host = ip
+connection_host = dns
 index = freenas
 source = freenas
 sourcetype = syslog
-
-[rest://Weather]
-auth_type = none
-endpoint = http://api.openweathermap.org/data/2.5/weather?q=Auckland,nz&units=metric&appid=YourAPIkey
-host = openweathermap.org
-http_method = GET
-index = freenas
-index_error_response_codes = 0
-polling_interval = 1000
-response_type = json
-sequential_mode = 0
-sourcetype = _json
-streaming_request = 0
 
 [rest://FreeNAS_storagesnapshots]
 auth_password = YourSecretPassword

--- a/default/props.conf
+++ b/default/props.conf
@@ -73,3 +73,9 @@ DATETIME_CONFIG =
 NO_BINARY_CHECK = true
 category = Custom
 pulldown_type = true
+
+[Userspace]
+REPORT-usps = uspace
+
+[Groupspace]
+REPORT-gsps = gspace

--- a/default/transform.conf
+++ b/default/transform.conf
@@ -1,0 +1,7 @@
+[uspace]
+DELIMS = " "
+FIELDS = "field1","field2","field3","field4","field5","field6","field7","field8","field9","UserName","RawSize"
+
+[gspace]
+DELIMS = " "
+FIELDS = "field1","field2","field3","field4","field5","field6","field7","field8","field9","GroupName","RawSize"


### PR DESCRIPTION
cpu_uptime_version_drives.sh - Freebsd has no /etc/version - approximated with uname.
nice.sh - Freebsd has many network interface names - ix, ixl, em, re, etc. Does freenas?
zpoolinfo.sh - not so sure about swapping from raw size in zpoolinfo.sh - this might be messy for people in production. kept same output fields except added compression. open to changes/rewrite.